### PR TITLE
Github repo transfer to jmxtrans organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://buildhive.cloudbees.com/job/cyrille-leclerc/job/jmxexporter/badge/icon)](https://buildhive.cloudbees.com/job/cyrille-leclerc/job/jmxexporter/)
+[![Build Status](https://buildhive.cloudbees.com/job/jmxtrans/job/embedded-jmxtrans/badge/icon)](https://buildhive.cloudbees.com/job/jmxtrans/job/embedded-jmxtrans/)
 
 # Embedded jmxtrans
 
@@ -7,6 +7,6 @@ In process JMX metrics exporter. Inspired by JMXTrans but embedded inside your j
 An in process JMX Exporter will solve the problem of remote JMX access in cloud-style and elastic environments where the IP address of the Java servers is unknown and where RMI-IIOP is disabled (e.g. Amazon Elastic Beanstalk, Cloudbees, ...).
 
 
-* [Documentation](https://github.com/cyrille-leclerc/jmxexporter/wiki)
-* [Latest javadocs](http://cyrille-leclerc.github.com/jmxexporter/apidocs/)
-* [Sample](https://github.com/cyrille-leclerc/jmxexporter-samples)
+* [Documentation](https://github.com/jmxtrans/embedded-jmxtrans/wiki)
+* [Latest javadocs](http://jmxtrans.github.com/embedded-jmxtrans/apidocs/)
+* [Sample](https://github.com/jmxtrans/embedded-jmxtrans-samples)

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,11 @@
     <packaging>jar</packaging>
     <name>embedded-jmxtrans</name>
     <description>In process JMX metrics exporter</description>
-    <url>https://github.com/cyrille-leclerc/jmxexporter</url>
+    <url>https://github.com/jmxtrans/embedded-jmxtrans</url>
     <scm>
-        <connection>scm:git:git@github.com:cyrille-leclerc/jmxexporter.git</connection>
-        <developerConnection>scm:git:git@github.com:cyrille-leclerc/jmxexporter.git</developerConnection>
-        <url>https://github.com/cyrille-leclerc/jmxexporter</url>
+        <connection>scm:git:git@github.com:jmxtrans/embedded-jmxtrans.git</connection>
+        <developerConnection>scm:git:git@github.com:jmxtrans/embedded-jmxtrans.git</developerConnection>
+        <url>https://github.com/jmxtrans/embedded-jmxtrans</url>
     </scm>
     <build>
         <plugins>


### PR DESCRIPTION
migrate https://github.com/cyrille-leclerc/jmxexporter ->
https://github.com/jmxtrans/embedded-jmxtrans
