### PR TITLE
Use dedicated hostname http://embedded-jmxtrans.jmxtrans.org to deploy javadocs

### DIFF
--- a/src/site/resources/CNAME
+++ b/src/site/resources/CNAME
@@ -1,0 +1,2 @@
+embedded-jmxtrans.jmxtrans.org
+


### PR DESCRIPTION
...mbedded-jmxtrans javadocs
