### PR TITLE
Adding a HTTP writer for Graphite

### DIFF
--- a/src/test/java/org/jmxtrans/embedded/output/GraphiteHttpWriterIntegrationTest.java
+++ b/src/test/java/org/jmxtrans/embedded/output/GraphiteHttpWriterIntegrationTest.java
@@ -41,8 +41,7 @@ public class GraphiteHttpWriterIntegrationTest {
     public void before() {
         graphiteHttpWriter = new GraphiteHttpWriter();
         Map<String, Object> settings = new HashMap<String, Object>();
-        settings.put(AbstractOutputWriter.SETTING_HOST, "127.0.0.1");
-        settings.put(AbstractOutputWriter.SETTING_PORT, 2013);
+        settings.put(AbstractOutputWriter.SETTING_URL, "http://10.1.4.33:2013/upload");
 
         graphiteHttpWriter.setSettings(settings);
         graphiteHttpWriter.start();


### PR DESCRIPTION
Hi,

The aim of this pull request is to pass through an HTTP Proxy to reach a graphite installed behind such a proxy.

The graphite behind the proxy needs to transform the HTTP POST sent by this new writer into a classic socket (see transformation done by a python proxy here : https://answers.launchpad.net/graphite/+question/213436)

I don't know if this specific need can help anyone else, but if so, here it is.

Simon
