### PR TITLE
Add the ability to specify the name of a Java System property for configuration

### DIFF
--- a/src/main/java/org/jmxtrans/embedded/servlet/EmbeddedJmxTransLoaderListener.java
+++ b/src/main/java/org/jmxtrans/embedded/servlet/EmbeddedJmxTransLoaderListener.java
@@ -134,7 +134,12 @@ public class EmbeddedJmxTransLoaderListener implements ServletContextListener {
             return null;
         }
 
-        return "file:///" + System.getProperty(configSystemProperty);
+        String prop = System.getProperty(configSystemProperty);
+        if (prop == null || prop.isEmpty()){
+            return null;
+        }
+
+        return "file:///" + prop;
     }
 
     private String configureFromWebXmlParam(ServletContextEvent sce){


### PR DESCRIPTION
Details:

-I added a new contex-param name "jmxtrans.system.config" that specifies the name of a system property
-Changed the EmbeddedJmxTransLoaderListener to check for that property being set first. If it is, it grabs the value, and then looks up the system property. If it is set, it uses that configuration file, if not it continues configuration exactly as before. 

-This is a nice feature because now a bundled WAR is configurable, instead of having to change the web.xml and rebuild the WAR.
