### PR TITLE
The path is missing in the JMXTrans objectName

### DIFF
--- a/src/main/java/org/jmxtrans/embedded/servlet/EmbeddedJmxTransLoaderListener.java
+++ b/src/main/java/org/jmxtrans/embedded/servlet/EmbeddedJmxTransLoaderListener.java
@@ -51,7 +51,7 @@ import java.util.List;
  *     &lt;param-name&gt;jmxtrans.config&lt;/param-name&gt;
  *     &lt;param-value&gt;
  *       classpath:jmxtrans.json
- *       classpath:org/jmxtrans/embedded/config/jmxtrans-internals.json
+ *       classpath:org/jmxtrans/embedded/config/jmxtrans-internals-servlet-container.json
  *       classpath:org/jmxtrans/embedded/config/tomcat-7.json
  *       classpath:org/jmxtrans/embedded/config/jvm-sun-hotspot.json
  *     &lt;/param-value&gt;
@@ -89,7 +89,7 @@ public class EmbeddedJmxTransLoaderListener implements ServletContextListener {
         if (configuration == null || configuration.isEmpty()){
             configuration = configureFromWebXmlParam(sce);
             if (configuration == null || configuration.isEmpty()){
-                configuration = "classpath:jmxtrans.json, classpath:org/jmxtrans/embedded/config/jmxtrans-internals.json";
+                configuration = "classpath:jmxtrans.json, classpath:org/jmxtrans/embedded/config/jmxtrans-internals-servlet-container.json";
             }
         }
 

--- a/src/main/resources/org/jmxtrans/embedded/config/jmxtrans-internals-servlet-container.json
+++ b/src/main/resources/org/jmxtrans/embedded/config/jmxtrans-internals-servlet-container.json
@@ -1,0 +1,17 @@
+{
+    "queries": [
+        {
+            "objectName": "org.jmxtrans.embedded:name=*,type=EmbeddedJmxTrans,path=*",
+            "resultAlias": "jmxtrans.%name%.%path%",
+            "attributes": [
+                "CollectedMetricsCount",
+                "CollectionCount",
+                "CollectionDurationInNanos",
+                "ExportCount",
+                "ExportDurationInNanos",
+                "ExportedMetricsCount"
+            ]
+
+        }
+    ]
+}


### PR DESCRIPTION
Without the ,path=\* part in the objectName, the jmxtrans-internals.json configuration file could not produce any metrics.
