### PR TITLE
Added support for other MBeanServer

### DIFF
--- a/src/main/java/org/jmxtrans/embedded/EmbeddedJmxTrans.java
+++ b/src/main/java/org/jmxtrans/embedded/EmbeddedJmxTrans.java
@@ -73,7 +73,16 @@ import java.util.concurrent.TimeUnit;
  */
 public class EmbeddedJmxTrans implements EmbeddedJmxTransMBean {
 
-    /**
+	public EmbeddedJmxTrans() {
+		super();
+	}
+	
+    public EmbeddedJmxTrans(MBeanServer mbeanServer) {
+		super();
+		this.mbeanServer = mbeanServer;
+	}
+
+	/**
      * Shutdown hook to collect and export metrics a last time if {@link EmbeddedJmxTrans#stop()} was not called.
      */
     private class EmbeddedJmxTransShutdownHook extends Thread {

--- a/src/main/java/org/jmxtrans/embedded/config/ConfigurationParser.java
+++ b/src/main/java/org/jmxtrans/embedded/config/ConfigurationParser.java
@@ -23,21 +23,30 @@
  */
 package org.jmxtrans.embedded.config;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.jmxtrans.embedded.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+import javax.management.MBeanServer;
+
+import org.jmxtrans.embedded.EmbeddedJmxTrans;
+import org.jmxtrans.embedded.EmbeddedJmxTransException;
+import org.jmxtrans.embedded.Query;
+import org.jmxtrans.embedded.QueryAttribute;
 import org.jmxtrans.embedded.output.OutputWriter;
 import org.jmxtrans.embedded.util.Preconditions;
 import org.jmxtrans.embedded.util.json.PlaceholderEnabledJsonNodeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * JSON Configuration parser to build {@link org.jmxtrans.embedded.EmbeddedJmxTrans}.
@@ -66,6 +75,15 @@ public class ConfigurationParser {
 
     public EmbeddedJmxTrans newEmbeddedJmxTrans(@Nonnull List<String> configurationUrls) throws EmbeddedJmxTransException {
         EmbeddedJmxTrans embeddedJmxTrans = new EmbeddedJmxTrans();
+
+        for (String configurationUrl : configurationUrls) {
+            mergeEmbeddedJmxTransConfiguration(configurationUrl, embeddedJmxTrans);
+        }
+        return embeddedJmxTrans;
+    }
+    
+    public EmbeddedJmxTrans newEmbeddedJmxTransWithCustomMBeanServer(@Nonnull List<String> configurationUrls, MBeanServer mbeanServer) throws EmbeddedJmxTransException {
+        EmbeddedJmxTrans embeddedJmxTrans = new EmbeddedJmxTrans(mbeanServer);
 
         for (String configurationUrl : configurationUrls) {
             mergeEmbeddedJmxTransConfiguration(configurationUrl, embeddedJmxTrans);


### PR DESCRIPTION
Sometimes you need an other MBean server.

For me (JBoss 4.2.3) I have 2 MBean servers in my webapp and ManagementFactory.getPlatformMBeanServer() gives me the last one, but I need the first (to get jboss:jca for example)

My servlet listener fetches the right MBeanServer:
MBeanServer customMBeanServer = MBeanServerFactory.findMBeanServer(null).get(0);

And start embedded-jmxtrans with this server:
embeddedJmxTrans = configurationParser.newEmbeddedJmxTransWithCustomMBeanServer(configurationUrls, customMBeanServer);
