### PR TITLE
Added hot configuration reloading for Spring

### DIFF
--- a/src/main/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransBeanDefinitionParser.java
+++ b/src/main/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransBeanDefinitionParser.java
@@ -15,23 +15,21 @@
  */
 package org.jmxtrans.embedded.spring;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jmxtrans.embedded.EmbeddedJmxTransException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.config.ListFactoryBean;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * {@link org.springframework.beans.factory.xml.BeanDefinitionParser} for an {@link EmbeddedJmxTransFactory}.
@@ -41,6 +39,7 @@ import java.util.List;
 public class EmbeddedJmxTransBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
 
     private static final String CONFIGURATION_ATTRIBUTE = "configuration";
+    private static final String CONFIGURATION_SCAN_PERIOD = "configuration-scan-period";
     private static final String IGNORE_CONFIGURATION_NOT_FOUND_ATTRIBUTE = "ignore-configuration-not-found";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -61,6 +60,10 @@ public class EmbeddedJmxTransBeanDefinitionParser extends AbstractSingleBeanDefi
         builder.setRole(BeanDefinition.ROLE_APPLICATION);
         builder.getRawBeanDefinition().setSource(parserContext.extractSource(element));
 
+        if (element.hasAttribute(CONFIGURATION_SCAN_PERIOD)) {
+            builder.addPropertyValue("configurationScanPeriod", element.getAttribute(CONFIGURATION_SCAN_PERIOD));
+        }
+        
         if (element.hasAttribute(IGNORE_CONFIGURATION_NOT_FOUND_ATTRIBUTE)) {
             builder.addPropertyValue("ignoreConfigurationNotFound", element.getAttribute(IGNORE_CONFIGURATION_NOT_FOUND_ATTRIBUTE));
         }

--- a/src/main/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransFactory.java
+++ b/src/main/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransFactory.java
@@ -95,8 +95,7 @@ public class EmbeddedJmxTransFactory implements FactoryBean<SpringEmbeddedJmxTra
                         loadConfiguration(embeddedJmxTrans, configurations);
                         embeddedJmxTrans.start();
                     } catch (Exception e) {
-                        logger.error("Error while reloading the configuration. Embedded JmxTrans disabled.", e);
-                        return;
+                        logger.error("Error while reloading the configuration. Embedded JmxTrans is disabled until the configuration is fixed.", e);
                     }
                 }
             }

--- a/src/main/resources/org/jmxtrans/embedded/spring/jmxtrans-1.0.xsd
+++ b/src/main/resources/org/jmxtrans/embedded/spring/jmxtrans-1.0.xsd
@@ -86,6 +86,16 @@
 				]]></xsd:documentation>
                 </xsd:annotation>
             </xsd:attribute>
+            <xsd:attribute name="configuration-scan-period" type="xsd:int"
+                           default="0">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+	Specifies the time interval in ms to check for configuration modifications. If modifications are detected, 
+	then the configuration is reloaded in JmxTrans.
+	Default is 0, meaning that the configuration reloading is disabled.
+				]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
         </xsd:complexType>
     </xsd:element>
 </xsd:schema>


### PR DESCRIPTION
Hi,

This is a proposal for hot configuration reloading for Spring.
It is based on a thread created by EmbeddedJmxTransFactory, which scans every X seconds (configurable) the last modification date of every configuration json file. 

If the last update date is greater than the last saved value, then:

1. the JmxTrans instance is stopped
2. the queries and output writers are cleaned
3. all configuration files are merged into jmxtrans
4. the JmxTrans instance is started again

A new attribute has been defined in jmxtrans-1.0.xsd, configuration-scan-period.
It corresponds to the new configurationScanPeriod attribute of EmbeddedJmxTransFactory. The new attribute is parsed and populated into EmbeddedJmxTransFactory by EmbeddedJmxTransBeanDefinitionParser.
If configuration-scan-period is 0 (default), then the hot configuration reloading is disabled (thread not created and started).

Regards,
Adrian