### PR TITLE
add a default constructor to class EmbeddedJmxTransFactory

### DIFF
--- a/src/main/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransFactory.java
+++ b/src/main/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransFactory.java
@@ -166,7 +166,12 @@ public class EmbeddedJmxTransFactory implements FactoryBean<SpringEmbeddedJmxTra
 	}
 
 
-    @Autowired
+    /**
+     * A default constructor is required
+     */
+    public EmbeddedJmxTransFactory() {
+    }
+
     public EmbeddedJmxTransFactory(ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
     }
@@ -279,4 +284,10 @@ public class EmbeddedJmxTransFactory implements FactoryBean<SpringEmbeddedJmxTra
 	public void setConfigurationScanPeriodInSeconds(int configurationScanPeriodInSeconds) {
 		this.configurationScanPeriodInSeconds = configurationScanPeriodInSeconds;
 	}
+
+    @Autowired
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
 }


### PR DESCRIPTION
added a default constructor to class EmbeddedJmxTransFactory

in order to avoid 
```
java.lang.NoSuchMethodException: org.jmxtrans.embedded.spring.EmbeddedJmxTransFactory.<init>() 
```
thrown in some case by Spring's SimpleInstantiationStrategy