### PR TITLE
Fix IllegalStateException with shutdown hook

### DIFF
--- a/src/main/java/org/jmxtrans/embedded/EmbeddedJmxTrans.java
+++ b/src/main/java/org/jmxtrans/embedded/EmbeddedJmxTrans.java
@@ -133,7 +133,7 @@ public class EmbeddedJmxTrans implements EmbeddedJmxTransMBean {
         }
 
         public void registerToRuntime() {
-            Runtime.getRuntime().addShutdownHook(shutdownHook);
+            Runtime.getRuntime().addShutdownHook(this);
         }
 
         public void unregisterFromRuntime() {

--- a/src/main/java/org/jmxtrans/embedded/EmbeddedJmxTrans.java
+++ b/src/main/java/org/jmxtrans/embedded/EmbeddedJmxTrans.java
@@ -153,12 +153,12 @@ public class EmbeddedJmxTrans implements EmbeddedJmxTransMBean {
             // if the shutdown hook was already executed by the Runtime
             // then we should not try to remove it from the Runtime otherwise we would get an IllegalStateException: Shutdown in progress
 
-            if (!shutdownHook.isAlreadyExecuted()) {
-                shutdownHook.unregisterFromRuntime();
+            if (!isAlreadyExecuted()) {
+                unregisterFromRuntime();
 
                 // as the shutdownHook was not already executed
                 // we want to execute it in order to trigger the last collection and export
-                shutdownHook.execute("EmbeddedJmxTrans Stop Handler");
+                execute("EmbeddedJmxTrans Stop Handler");
             }
         }
 

--- a/src/test/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransFactoryTest.java
+++ b/src/test/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransFactoryTest.java
@@ -50,4 +50,25 @@ public class EmbeddedJmxTransFactoryTest {
         embeddedJmxTrans.stop();
 
     }
+
+    @Test
+    public void testGetObjectMultipleTimes() throws Exception {
+        String configuration = "classpath:org/jmxtrans/embedded/jmxtrans-factory-test.json";
+        EmbeddedJmxTransFactory factory = new EmbeddedJmxTransFactory(new DefaultResourceLoader());
+        factory.setConfigurationUrl(configuration);
+
+        EmbeddedJmxTrans embeddedJmxTrans = factory.getObject();
+        assertThat(embeddedJmxTrans, notNullValue());
+        assertThat(embeddedJmxTrans.getQueries().size(), is(8));
+        assertThat(embeddedJmxTrans.getOutputWriters().size(), is(1));
+
+        embeddedJmxTrans.stop();
+
+        embeddedJmxTrans.start();
+        embeddedJmxTrans.stop();
+
+        embeddedJmxTrans.start();
+        embeddedJmxTrans.stop();
+    }
+
 }


### PR DESCRIPTION
This fixes the following message 
```
org.springframework.beans.factory.support.DisposableBeanAdapter - Invocation of destroy method failed on bean with name 'jmxtrans': java.lang.IllegalStateException: Shutdown in progress
```
that may occur when a Spring Web Application is shutdown
