### PR TITLE
Removed usage of class introduced in Java 7

### DIFF
--- a/src/main/java/org/jmxtrans/embedded/output/GraphiteWriter.java
+++ b/src/main/java/org/jmxtrans/embedded/output/GraphiteWriter.java
@@ -33,7 +33,7 @@ import org.jmxtrans.embedded.util.pool.UDPSocketWriterPoolFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -61,6 +61,8 @@ import java.util.concurrent.TimeUnit;
 public class GraphiteWriter extends AbstractOutputWriter implements OutputWriter {
 
     public static final int DEFAULT_GRAPHITE_SERVER_PORT = 2003;
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private static final String PROTOCOL_TCP = "TCP";
     private static final String PROTOCOL_UDP = "UDP";
@@ -111,7 +113,7 @@ public class GraphiteWriter extends AbstractOutputWriter implements OutputWriter
 
         String protocol = getStringSetting(SETTING_PROTOCOL, null);
         if (protocol != null && protocol.equalsIgnoreCase(PROTOCOL_UDP)) {
-            socketWriterPool = new GenericKeyedObjectPool<HostAndPort, SocketWriter>(new UDPSocketWriterPoolFactory(StandardCharsets.UTF_8), config);
+            socketWriterPool = new GenericKeyedObjectPool<HostAndPort, SocketWriter>(new UDPSocketWriterPoolFactory(UTF_8), config);
         } else {
             if (protocol == null) {
                 // protocol not specified, use default one
@@ -120,7 +122,7 @@ public class GraphiteWriter extends AbstractOutputWriter implements OutputWriter
                 // unknown or protocol, use default one
                 logger.warn("Unknown protocol specified '{}', default protocol '{}' will be used instead.",protocol, PROTOCOL_TCP);
             }
-            socketWriterPool = new GenericKeyedObjectPool<HostAndPort, SocketWriter>(new SocketWriterPoolFactory(StandardCharsets.UTF_8, socketConnectTimeoutInMillis), config);
+            socketWriterPool = new GenericKeyedObjectPool<HostAndPort, SocketWriter>(new SocketWriterPoolFactory(UTF_8, socketConnectTimeoutInMillis), config);
         }
 
         if (isEnabled()) {

--- a/src/main/java/org/jmxtrans/embedded/output/StatsDWriter.java
+++ b/src/main/java/org/jmxtrans/embedded/output/StatsDWriter.java
@@ -11,7 +11,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -26,6 +26,8 @@ public class StatsDWriter extends AbstractOutputWriter implements OutputWriter {
     public final static String SETTING_BUFFER_SIZE = "bufferSize";
     private final static int SETTING_DEFAULT_BUFFER_SIZE = 1024;
     public static final String DEFAULT_NAME_PREFIX = "servers.#escaped_hostname#.";
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private ByteBuffer sendBuffer;
     /**
@@ -82,7 +84,7 @@ public class StatsDWriter extends AbstractOutputWriter implements OutputWriter {
             String stat = metricPathPrefix + result.getName() + ":" + result.getValue() + "|" + getStatsdMetricType(result) + "\n";
 
             logger.debug("Export '{}'", stat);
-            final byte[] data = stat.getBytes(StandardCharsets.UTF_8);
+            final byte[] data = stat.getBytes(UTF_8);
 
             // If we're going to go past the threshold of the buffer then flush.
             // the +1 is for the potential '\n' in multi_metrics below


### PR DESCRIPTION
StandardCharsets class was introduced in Java 7.
Inlined code so that it can be compiled in Java 6 (as the pom states source is 1.6)