### PR TITLE
Predictable Tomcat NIO Metric Names

### DIFF
--- a/src/main/resources/org/jmxtrans/embedded/config/cloudbees-tomcat-6.json
+++ b/src/main/resources/org/jmxtrans/embedded/config/cloudbees-tomcat-6.json
@@ -1,8 +1,17 @@
 {
     "queries": [
         {
-            "objectName": "localEngine:type=ThreadPool,name=*",
-            "resultAlias": "tomcat.thread-pool.%name%",
+            "objectName": "localEngine:type=ThreadPool,name=\"http-nio-*\"",
+            "resultAlias": "tomcat.thread-pool.http-nio",
+            "attributes": [
+                "currentThreadCount",
+                "currentThreadsBusy"
+            ]
+
+        },
+        {
+            "objectName": "localEngine:type=ThreadPool,name=\"ajp-nio-*\"",
+            "resultAlias": "tomcat.thread-pool.ajp-nio",
             "attributes": [
                 "currentThreadCount",
                 "currentThreadsBusy"
@@ -17,8 +26,20 @@
             ]
         },
         {
-            "objectName": "localEngine:type=GlobalRequestProcessor,name=*",
-            "resultAlias": "tomcat.global-request-processor.%name%",
+            "objectName": "localEngine:type=GlobalRequestProcessor,name=\"http-nio-*\"",
+            "resultAlias": "tomcat.global-request-processor.http-nio",
+            "attributes": [
+                "bytesReceived",
+                "bytesSent",
+                "errorCount",
+                "processingTime",
+                "requestCount"
+
+            ]
+        },
+        {
+            "objectName": "localEngine:type=GlobalRequestProcessor,name=\"ajp-nio-*\"",
+            "resultAlias": "tomcat.global-request-processor.ajp-nio",
             "attributes": [
                 "bytesReceived",
                 "bytesSent",

--- a/src/main/resources/org/jmxtrans/embedded/config/tomcat-6.json
+++ b/src/main/resources/org/jmxtrans/embedded/config/tomcat-6.json
@@ -1,8 +1,17 @@
 {
     "queries": [
         {
-            "objectName": "Catalina:type=ThreadPool,name=*",
-            "resultAlias": "tomcat.thread-pool.%name%",
+            "objectName": "Catalina:type=ThreadPool,name=\"http-nio-*\"",
+            "resultAlias": "tomcat.thread-pool.http-nio",
+            "attributes": [
+                "currentThreadCount",
+                "currentThreadsBusy"
+            ]
+
+        },
+        {
+            "objectName": "Catalina:type=ThreadPool,name=\"ajp-nio-*\"",
+            "resultAlias": "tomcat.thread-pool.ajp-nio",
             "attributes": [
                 "currentThreadCount",
                 "currentThreadsBusy"
@@ -17,8 +26,20 @@
             ]
         },
         {
-            "objectName": "Catalina:type=GlobalRequestProcessor,name=*",
-            "resultAlias": "tomcat.global-request-processor.%name%",
+            "objectName": "Catalina:type=GlobalRequestProcessor,name=\"http-nio-*\"",
+            "resultAlias": "tomcat.global-request-processor.http-nio",
+            "attributes": [
+                "bytesReceived",
+                "bytesSent",
+                "errorCount",
+                "processingTime",
+                "requestCount"
+
+            ]
+        },
+        {
+            "objectName": "Catalina:type=GlobalRequestProcessor,name=\"ajp-nio-*\"",
+            "resultAlias": "tomcat.global-request-processor.ajp-nio",
             "attributes": [
                 "bytesReceived",
                 "bytesSent",

--- a/src/main/resources/org/jmxtrans/embedded/config/tomcat-7.json
+++ b/src/main/resources/org/jmxtrans/embedded/config/tomcat-7.json
@@ -1,8 +1,17 @@
 {
     "queries": [
         {
-            "objectName": "Catalina:type=ThreadPool,name=*",
-            "resultAlias": "tomcat.thread-pool.%name%",
+            "objectName": "Catalina:type=ThreadPool,name=\"http-nio-*\"",
+            "resultAlias": "tomcat.thread-pool.http-nio",
+            "attributes": [
+                "currentThreadCount",
+                "currentThreadsBusy"
+            ]
+
+        },
+        {
+            "objectName": "Catalina:type=ThreadPool,name=\"ajp-nio-*\"",
+            "resultAlias": "tomcat.thread-pool.ajp-nio",
             "attributes": [
                 "currentThreadCount",
                 "currentThreadsBusy"
@@ -17,8 +26,20 @@
             ]
         },
         {
-            "objectName": "Catalina:type=GlobalRequestProcessor,name=*",
-            "resultAlias": "tomcat.global-request-processor.%name%",
+            "objectName": "Catalina:type=GlobalRequestProcessor,name=\"http-nio-*\"",
+            "resultAlias": "tomcat.global-request-processor.http-nio",
+            "attributes": [
+                "bytesReceived",
+                "bytesSent",
+                "errorCount",
+                "processingTime",
+                "requestCount"
+
+            ]
+        },
+        {
+            "objectName": "Catalina:type=GlobalRequestProcessor,name=\"ajp-nio-*\"",
+            "resultAlias": "tomcat.global-request-processor.ajp-nio",
             "attributes": [
                 "bytesReceived",
                 "bytesSent",

--- a/src/test/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransBeanDefinitionParser1Test.java
+++ b/src/test/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransBeanDefinitionParser1Test.java
@@ -49,7 +49,7 @@ public class EmbeddedJmxTransBeanDefinitionParser1Test {
     @Test
     public void test() {
         Map<String, Query> queries = TestUtils.indexQueriesByAliasOrName(embeddedJmxTrans.getQueries());
-        Query tomcatProcessorQuery = queries.get("tomcat.global-request-processor.%name%");
+        Query tomcatProcessorQuery = queries.get("tomcat.global-request-processor.http-nio");
         assertNotNull(tomcatProcessorQuery);
     }
 }

--- a/src/test/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransBeanDefinitionParser2Test.java
+++ b/src/test/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransBeanDefinitionParser2Test.java
@@ -48,7 +48,7 @@ public class EmbeddedJmxTransBeanDefinitionParser2Test {
     @Test
     public void test() {
         Map<String,Query> queries = TestUtils.indexQueriesByAliasOrName(embeddedJmxTrans.getQueries());
-        Query tomcatProcessorQuery = queries.get("tomcat.global-request-processor.%name%");
+        Query tomcatProcessorQuery = queries.get("tomcat.global-request-processor.http-nio");
         assertNotNull(tomcatProcessorQuery);
     }
 }

--- a/src/test/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransBeanDefinitionParser3Test.java
+++ b/src/test/java/org/jmxtrans/embedded/spring/EmbeddedJmxTransBeanDefinitionParser3Test.java
@@ -49,7 +49,7 @@ public class EmbeddedJmxTransBeanDefinitionParser3Test {
     @Test
     public void test() {
         Map<String, Query> queries = TestUtils.indexQueriesByAliasOrName(embeddedJmxTrans.getQueries());
-        Query tomcatProcessorQuery = queries.get("tomcat.global-request-processor.%name%");
+        Query tomcatProcessorQuery = queries.get("tomcat.global-request-processor.http-nio");
         assertNotNull(tomcatProcessorQuery);
     }
 }


### PR DESCRIPTION
Use a predictable resultAlias value for each possible Tomcat ThreadPool and GlobalRequestProcessor

http-nio and ajp-nio Thread Pools and GlobalRequestProcessor MBean's names are always suffixed with the port number (for instance http-nio-8080). When the port number is randomly assigned (running in a PaaS like CloudFoundry), metrics will have different names every times tomcat is (re)started. This can be an issue in case you have a metric quota on the backend (when using hosted service like hostedgraphite.com). Even in the absence of a quota, it will simply fillup the backend disk partition really quickly. Also the metrics will be shortlive, and won't be easy to aggregate in the long run.

In order to fix that, we match each individual ObjectName with its prefix (commonly "http-nio-" and "ajp-nio-" in Tomcat) followed with a wildcard for the port number we don't know in advance. The resultAlias will not contain the port number at all, but transform to "http-nio" and "ajp-nio" respectively.

Note that when using a wildcard in a litteral attribute matcher, the value should be enclosed in double-quotes.