### PR TITLE
renamed Integration Test class to match the surefire exclude pattern

### DIFF
--- a/src/test/java/org/jmxtrans/embedded/output/GraphiteWriterUDPIntegrationTest.java
+++ b/src/test/java/org/jmxtrans/embedded/output/GraphiteWriterUDPIntegrationTest.java
@@ -37,7 +37,7 @@ import java.util.Map;
 /**
  * @author <a href="mailto:patrick.bruehlmann@gmail.com">Patrick Brühlmann</a>
  */
-public class GraphiteWriterIntegrationUDPTest {
+public class GraphiteWriterUDPIntegrationTest {
 
     GraphiteWriter graphiteWriter;
 


### PR DESCRIPTION
this is a trivial fix : 
renamed Integration Test class to match the surefire exclude pattern (should end with IntegrationTest)