### PR TITLE
Improve ByteBuffer management

### DIFF
--- a/src/main/java/org/jmxtrans/embedded/output/StatsDWriter.java
+++ b/src/main/java/org/jmxtrans/embedded/output/StatsDWriter.java
@@ -126,9 +126,7 @@ public class StatsDWriter extends AbstractOutputWriter implements OutputWriter {
             addressReference.purge();
             logger.warn("Could not send stat {} to host {}:{}", sendBuffer, address.getHostName(), address.getPort(), e);
         } finally {
-            // why do we need redefine the limit?
-            sendBuffer.limit(sendBuffer.capacity());
-            sendBuffer.rewind();
+            sendBuffer.clear();
         }
     }
 


### PR DESCRIPTION
Using clear() reset the limit to the ByteBuffer capacity.
The rewind() is unnecessary after the flip(): position is already set to zero.