### PR TITLE
explicitly set the version for plugin maven-bundle-plugin, in order to allow the project to build with Java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven-bundle-plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <supportedProjectTypes>
@@ -303,6 +304,7 @@
             </activation>
             <properties>
                 <findbugs.plugin.version>2.5.5</findbugs.plugin.version>
+                <maven-bundle-plugin.version>2.5.4</maven-bundle-plugin.version>
             </properties>
         </profile>
         <profile>
@@ -312,6 +314,7 @@
             </activation>
             <properties>
                 <findbugs.plugin.version>2.5.5</findbugs.plugin.version>
+                <maven-bundle-plugin.version>3.0.0</maven-bundle-plugin.version>
             </properties>
         </profile>
         <profile>
@@ -321,6 +324,7 @@
             </activation>
             <properties>
                 <findbugs.plugin.version>3.0.1</findbugs.plugin.version>
+                <maven-bundle-plugin.version>3.0.0</maven-bundle-plugin.version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
In September 2015, a new version of maven plugin ```org.apache.felix:maven-bundle-plugin```, that is version ```3.0.0```. Previous latest version was ```2.5.4``` since April 2015.

It seems that version ```3.0.0``` is now depending on other lib that requires Java 7, because since then, building embedded-jmxtrans with Java 6 can fail with the following error :

```
[INFO] --- maven-bundle-plugin:3.0.0:manifest (bundle-manifest) @ embedded-jmxtrans ---
[WARNING] Error injecting: org.apache.felix.bundleplugin.ManifestPlugin
java.lang.UnsupportedClassVersionError: aQute/bnd/osgi/Analyzer : Unsupported major.minor version 51.0
```

I build the framework on a regular basis with Java 6 to ensure new code does not break things for Java 6 users (not me).

```pom.xml``` does not explicitly set the version for this plugin, as maven warns at build startup

```
[WARNING] Some problems were encountered while building the effective model for org.jmxtrans.embedded:embedded-jmxtrans:jar:1.1.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.felix:maven-bundle-plugin is missing. @ line 66, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 58, column 21
```

Setting the version explicitly for this plugin will fix the warning.
Setting the version to ```2.5.4``` will allow to build embedded-jmxtrans with Java 6.

This PR actually set the version to ```2.5.4``` when maven is running with Java 6, or set the version to ```3.0.0``` when maven is running with Java 7 or higher.
