### PR TITLE
Retrieve configuration from a key value store

### DIFF
--- a/src/main/java/org/jmxtrans/embedded/config/ConfigurationParser.java
+++ b/src/main/java/org/jmxtrans/embedded/config/ConfigurationParser.java
@@ -23,6 +23,7 @@
  */
 package org.jmxtrans.embedded.config;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -109,9 +110,16 @@ public class ConfigurationParser {
                 InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
                 Preconditions.checkNotNull(in, "No file found for '" + configurationUrl + "'");
                 mergeEmbeddedJmxTransConfiguration(in, embeddedJmxTrans);
+            } else if (configurationUrl.startsWith("etcd:")) {
+                KVStore kvs = new EtcdKVStore();
+                String jsonConf = kvs.getKeyValue(configurationUrl).getValue();
+                Preconditions.checkNotNull(jsonConf, "No value found for '" + configurationUrl + "'");
+                InputStream in = new ByteArrayInputStream(jsonConf.getBytes("UTF-8"));
+                mergeEmbeddedJmxTransConfiguration(in, embeddedJmxTrans);
             } else {
                 mergeEmbeddedJmxTransConfiguration(new URL(configurationUrl), embeddedJmxTrans);
             }
+
         } catch (JsonProcessingException e) {
             throw new EmbeddedJmxTransException("Exception loading configuration'" + configurationUrl + "': " + e.getMessage(), e);
         } catch (Exception e) {

--- a/src/main/java/org/jmxtrans/embedded/config/EtcdKVStore.java
+++ b/src/main/java/org/jmxtrans/embedded/config/EtcdKVStore.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.jmxtrans.embedded.config;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.jmxtrans.embedded.EmbeddedJmxTransException;
+
+import mousio.etcd4j.EtcdClient;
+import mousio.etcd4j.promises.EtcdResponsePromise;
+import mousio.etcd4j.responses.EtcdException;
+import mousio.etcd4j.responses.EtcdKeysResponse;
+
+/**
+ * This is an etcd based KVStore implementation. The connection to etcd is estabilished and closed
+ * every time a key is read. This is by design since we don't need to read a lot of keys and we do
+ * it at relativly long interval times
+ */
+public class EtcdKVStore implements KVStore {
+
+  /**
+   *
+   */
+  public EtcdKVStore() {
+    // TODO Auto-generated constructor stub
+  }
+
+  /**
+   * Questo metodo
+   *
+   * @param KeyURI
+   * @return
+   * @throws EmbeddedJmxTransException
+   *
+   * @see org.jmxtrans.embedded.config.KVStore#getKeyValue(java.lang.String)
+   */
+  public KeyValue getKeyValue(String KeyURI) throws EmbeddedJmxTransException {
+
+    String etcdURI = KeyURI.substring(0, KeyURI.indexOf("/", 7));
+    String key = KeyURI.substring(KeyURI.indexOf("/", 7));
+    EtcdClient etcd = null;
+    try {
+      etcd = new EtcdClient(URI.create(etcdURI));
+      EtcdResponsePromise<EtcdKeysResponse> conf = etcd.get(key).send();
+      EtcdKeysResponse resp = conf.get();
+      String keyVal = resp.node.value;
+
+      return new KeyValue(keyVal, Long.toString(resp.node.modifiedIndex));
+
+    } catch (EtcdException e) {
+      if (e.errorCode == 100) {
+        return null;
+      } else {
+        throw new EmbeddedJmxTransException("Exception reading etcd key '" + KeyURI + "': " + e.getMessage(), e);
+      }
+
+    } catch (Throwable t) {
+      throw new EmbeddedJmxTransException("Exception reading etcd key '" + KeyURI + "': " + t.getMessage(), t);
+    } finally {
+      try {
+        if (etcd != null) {
+          etcd.close();
+        }
+      } catch (IOException e) {
+        // Nothing to do closing
+      }
+    }
+  }
+
+}

--- a/src/main/java/org/jmxtrans/embedded/config/EtcdKVStore.java
+++ b/src/main/java/org/jmxtrans/embedded/config/EtcdKVStore.java
@@ -1,15 +1,15 @@
 /*
  * Copyright (c) 2016 the original author or authors
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -38,6 +38,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * This is an etcd based KVStore implementation. The connection to etcd is estabilished and closed
  * every time a key is read. This is by design since we don't need to read a lot of keys and we do
  * it at relativly long interval times
+ *
+ * @author Simone Zorzetti
  */
 public class EtcdKVStore implements KVStore {
 
@@ -49,6 +51,9 @@ public class EtcdKVStore implements KVStore {
     mapper.setNodeFactory(new PlaceholderEnabledJsonNodeFactory());
   }
 
+  /**
+   * Bean for a simplified etcd node
+   */
   public static class EtcdNode {
     private String key;
     private long createdIndex;
@@ -114,6 +119,9 @@ public class EtcdKVStore implements KVStore {
 
   }
 
+  /**
+   * Bean for a simplified etcd answer (just for GET)
+   */
   public static class EtcdResult {
     // General values
     private String action;

--- a/src/main/java/org/jmxtrans/embedded/config/KVStore.java
+++ b/src/main/java/org/jmxtrans/embedded/config/KVStore.java
@@ -1,15 +1,15 @@
 /*
  * Copyright (c) 2016 the original author or authors
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -25,6 +25,8 @@ import org.jmxtrans.embedded.EmbeddedJmxTransException;
 /**
  * This interface represents a super simplified key value store from which you can only read keys.
  * You get back the key value and a version id
+ *
+ * @author Simone Zorzetti
  */
 public interface KVStore {
 

--- a/src/main/java/org/jmxtrans/embedded/config/KVStore.java
+++ b/src/main/java/org/jmxtrans/embedded/config/KVStore.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2010-2013 the original author or authors
- * 
+ * Copyright (c) 2016 the original author or authors
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -23,15 +23,19 @@ package org.jmxtrans.embedded.config;
 import org.jmxtrans.embedded.EmbeddedJmxTransException;
 
 /**
- * This interface represents a super simplified key value store
+ * This interface represents a super simplified key value store from which you can only read keys.
+ * You get back the key value and a version id
  */
 public interface KVStore {
 
   /**
-   * Retrieves the value of a key from the kv store
+   * Retrieves the value of a key from the kv store. The version can be used to determine if a key
+   * was changed since the last read
    *
-   * @param KeyURI: uri of the key eg: etcd://127.0.0.1:123/level1/config
-   * @return
+   * @param KeyURI: uri of the key eg: etcd://127.0.0.1:123/level1/config for a cluster you can use
+   *        etcd://[ipaddr1:port1, ipaddr:port2,...]:/path
+   * @return a KeyValue object which hold the key value and the version id (modification index or
+   *         trx id)
    * @throws EmbeddedJmxTransException
    */
   public KeyValue getKeyValue(String KeyURI) throws EmbeddedJmxTransException;

--- a/src/main/java/org/jmxtrans/embedded/config/KVStore.java
+++ b/src/main/java/org/jmxtrans/embedded/config/KVStore.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+package org.jmxtrans.embedded.config;
+
+import org.jmxtrans.embedded.EmbeddedJmxTransException;
+
+/**
+ * This interface represents a super simplified key value store
+ */
+public interface KVStore {
+
+  /**
+   * Retrieves the value of a key from the kv store
+   *
+   * @param KeyURI: uri of the key eg: etcd://127.0.0.1:123/level1/config
+   * @return
+   * @throws EmbeddedJmxTransException
+   */
+  public KeyValue getKeyValue(String KeyURI) throws EmbeddedJmxTransException;
+
+}

--- a/src/main/java/org/jmxtrans/embedded/config/KeyValue.java
+++ b/src/main/java/org/jmxtrans/embedded/config/KeyValue.java
@@ -20,10 +20,12 @@
 package org.jmxtrans.embedded.config;
 
 /**
- * This class is a value retrieved from a key value store. Associated with the value comes the
- * version. The version is a unique id of the value of the key it can be used to determine if a key
- * has been changed. Etcd and Consul use an "index", a monotone incrementing number, Zookeeper uses
- * transaction ids
+ * This class represents a value retrieved from a key value store. Associated with the value comes
+ * the version. The version is a unique for the value of the key. It can be used to determine if a
+ * key has been changed. Etcd and Consul use an "index", a monotonically incrementing number,
+ * Zookeeper uses transaction ids
+ *
+ * @author Simone Zorzetti
  */
 public class KeyValue {
 

--- a/src/main/java/org/jmxtrans/embedded/config/KeyValue.java
+++ b/src/main/java/org/jmxtrans/embedded/config/KeyValue.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.jmxtrans.embedded.config;
+
+/**
+ * This class is a value retrieved from a key value store. Associated with the value comes the
+ * version. The version is a unique id of the value of the key it can be used to determine if a key
+ * has been changed. Etcd and Consul use an "index", a monotone incrementing number, Zookeeper uses
+ * transaction ids
+ */
+public class KeyValue {
+
+  private final String value;
+  private final String version;
+
+  /**
+   * Constructor
+   */
+  public KeyValue(String val, String idx) {
+    value = val;
+    version = idx;
+  }
+
+  /**
+   * The value of the key
+   *
+   * @return
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * The version of the key
+   *
+   * @return
+   */
+  public String getVersion() {
+    return version;
+  }
+
+
+}

--- a/src/main/java/org/jmxtrans/embedded/config/KeyValue.java
+++ b/src/main/java/org/jmxtrans/embedded/config/KeyValue.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2010-2013 the original author or authors
- * 
+ * Copyright (c) 2016 the original author or authors
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,


### PR DESCRIPTION
This PR introduces the ability to retrieve configuration excerpts from a remote key value store. A very simple interface is defined and an implementation based on Etcd is supplied. The enhancement is very smoothly integrated into the present configuration mechanism. 
I have modified the ConfigurationParser class enabling it to recognize urls like etcd://127.0.0.1:4001/query or etcd://[ipaddr1:port1, ipaddr:port2,...]:/path to address a cluster.
 
I have initially experimented with the etcd4j client but it consumed too much resources when active (more than 20 threads during refresh). Since I think that an embedded-jmxtrans should be almost invisible I have implemented e simplified read only etcd client.

The ultimate goal of this PR is to enable the central management of the jmxtrans configuration of a lot of application servers running on virtual machines or docker containers.
To do this I have created a very small "agent" webapp  https://github.com/golorins/embedded-jmxtrans-war which uses this feature to implement a simple but powerful configuration scheme. 
If you like this PR have a look at it, and let me know what you think 
