### PR TITLE
Export package org.jmxtrans.embedded.output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
                     </supportedProjectTypes>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Export-Package>org.jmxtrans.embedded,org.jmxtrans.embedded.config,org.jmxtrans.embedded.servlet</Export-Package>
+                        <Export-Package>org.jmxtrans.embedded,org.jmxtrans.embedded.config,org.jmxtrans.embedded.servlet,org.jmxtrans.embedded.output</Export-Package>
                         <Private-Package>org.jmxtrans.embedded.util.*</Private-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
I need to implement a CustomOutputWrite extends AbstractOutputWriter implements OutputWriter.
This does not currently work in an OSGi-context, because the package org.jmxtrans.embedded.output  is not exported, and AbstractOutputWriter and OutputWriter can't be loaded. This change should fix that.