### PR TITLE
Support for dynamic mbeans.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ Create `src/main/resources/jmxtrans.json`, add your mbeans and declare both `Con
 
 In this sample, Graphite host & port are defaulted to `localhost:2003` and can be overwritten with system properties or environment variables, for example in `$CATALINA_BASE/conf/catalina.properties`.
 
+#### Dynamic MBeans
+
+If metrics are provided by a Dynamic MBean all attributes can be collected by declaring an empty attributes array, for example :
+ 
+```json
+{
+  "queries": [
+    {
+      "objectName": "com.cocktail:type=CocktailService,name=cocktailService",
+      "resultAlias": "cocktail.controller",
+      "attributes": [ ]
+    }
+  ]
+}
+```
+
 ### Start application and check metrics
 
 #### Check metrics in the Console

--- a/src/main/java/org/jmxtrans/embedded/Query.java
+++ b/src/main/java/org/jmxtrans/embedded/Query.java
@@ -75,7 +75,7 @@ public class Query implements QueryMBean {
      * JMX attributes to collect. As an array for {@link javax.management.MBeanServer#getAttributes(javax.management.ObjectName, String[])}
      */
     @Nonnull
-    private Map<String, QueryAttribute> attributesByName = new HashMap<String, QueryAttribute>();
+    private final Map<String, QueryAttribute> attributesByName = new HashMap<String, QueryAttribute>();
     /**
      * Copy of {@link #attributesByName}'s {@link java.util.Map#entrySet()} for performance optimization
      */
@@ -166,6 +166,11 @@ public class Query implements QueryMBean {
                 logger.trace("Query {} returned {}", matchingObjectName, jmxAttributes);
                 for (Attribute jmxAttribute : jmxAttributes.asList()) {
                     QueryAttribute queryAttribute = this.attributesByName.get(jmxAttribute.getName());
+                    if (queryAttribute == null) { // support for dynamic attributes
+                        logger.trace("Creating query attribute for {}", jmxAttribute.getName());
+                        queryAttribute = new QueryAttribute(jmxAttribute.getName(), null, null);
+                        addAttribute(queryAttribute);
+                    }
                     Object value = jmxAttribute.getValue();
                     int count = queryAttribute.collectMetrics(matchingObjectName, value, epochInMillis, this.queryResults);
                     collectedMetricsCount.addAndGet(count);


### PR DESCRIPTION
Currently for every query definition every attribute must be defined, unfortunately this does not play well with dynamic mbeans.