### PR TITLE
Add capacity option to allow for queries with more than 200 results

### DIFF
--- a/src/test/java/org/jmxtrans/embedded/config/ConfigurationTest.java
+++ b/src/test/java/org/jmxtrans/embedded/config/ConfigurationTest.java
@@ -27,6 +27,7 @@ package org.jmxtrans.embedded.config;
 import org.jmxtrans.embedded.EmbeddedJmxTrans;
 import org.jmxtrans.embedded.Query;
 import org.jmxtrans.embedded.QueryAttribute;
+import org.jmxtrans.embedded.QueryResult;
 import org.jmxtrans.embedded.TestUtils;
 import org.jmxtrans.embedded.output.*;
 import org.junit.BeforeClass;
@@ -35,6 +36,7 @@ import org.junit.Test;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import java.util.*;
+import java.util.concurrent.BlockingQueue;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -214,4 +216,14 @@ public class ConfigurationTest {
         assertThat(embeddedJmxTrans.getExportIntervalInSeconds(), is(10));
         assertThat(embeddedJmxTrans.getNumExportThreads(), is(2));
     }
+
+    @Test
+    public void validateQueryWithCapacity() throws MalformedObjectNameException {
+        ObjectName objectName = new ObjectName("java.lang:type=MemoryPool,name=*");
+        Query query = queriesByResultName.get("test-with-capacity.%name%");
+        assertThat(query.getObjectName(), is(objectName));
+        BlockingQueue<QueryResult> results = query.getResults();
+        assertThat(results.remainingCapacity(), is(500));
+    }
+
 }

--- a/src/test/resources/org/jmxtrans/embedded/jmxtrans-config-test.json
+++ b/src/test/resources/org/jmxtrans/embedded/jmxtrans-config-test.json
@@ -77,6 +77,12 @@
                     "@class": "org.jmxtrans.embedded.output.NoOpWriter"
                 }
             ]
+        },
+        {
+            "objectName": "java.lang:type=MemoryPool,name=*",
+            "resultAlias": "test-with-capacity.%name%",
+            "attribute": "CollectionUsageThresholdCount",
+            "capacity": 500
         }
     ],
     "outputWriters": [


### PR DESCRIPTION
For queries where we anticipate more than 200 results to be collected, let's allow adding an explicit configuration for the capacity.